### PR TITLE
Experimental support for Aarch64/AMD64

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ Page link : [COPR package](https://copr.fedorainfracloud.org/coprs/emixampp/syno
    3. `sudo dnf install ~/rpmbuild/RPMS/x86_64/synology-drive-noextra-*.x86_64.rpm`
 7. Clean build root : `rm -r ~/rpmbuild`
 
+### Experimental: build the package locally for Aarch64/ARM64 processors (e.g. Apple Silicon, Qualcomm Snapdragon)
+1. Install build tools : `sudo dnf install rpm-build rpmdevtools`
+2. `git clone https://github.com/EmixamPP/synology-drive.git`
+3. `cd synology-drive`
+4. Optional, if you want to change the version:
+   1. Consult the [release notes](https://www.synology.com/en-global/releaseNote/SynologyDriveClient) and choose the desired version (>= 3.2.1-13271)
+   2. Edit the two first lines of `synology-drive.spec` or `synology-drive-noextra.spec`, depending on whether you are running GNOME or another desktop environement. 
+5. For GNOME:
+   1. `spectool -g -R synology-drive-aarch64.spec`
+   2. `rpmbuild -ba synology-drive-aarch64.spec`
+   3. `sudo dnf install ~/rpmbuild/RPMS/x86_64/synology-drive-*.aarch64.rpm`
+6. For other desktop environments: 
+   1. `spectool -g -R synology-drive-aarch64-noextra.spec`
+   2. `rpmbuild -ba synology-drive-aarch64-noextra.spec`
+   3. `sudo dnf install ~/rpmbuild/RPMS/x86_64/synology-drive-noextra-*.aarch64.rpm`
+7. Clean build root : `rm -r ~/rpmbuild`
+**Attention**_**: This solution uses the FEX emulator. If you are using the QEMU emulator it will probalby break because binfmt_misc allows only one emulator to register for x86_64 binaries.
+
 ## Legal information
 Consult the [LICENSE](https://github.com/EmixamPP/synology-drive/blob/main/LICENSE).
 

--- a/synology-drive-aarch64-noextra.spec
+++ b/synology-drive-aarch64-noextra.spec
@@ -1,0 +1,91 @@
+%global synology_version 4.0.2
+%global synology_release 17889
+
+Name:      synology-drive-noextra
+Version:   %{synology_version}
+Release:   %{synology_release}%{?dist}
+Summary:   Unofficial RPM build of Synology Drive Client without extra dependencies
+License:   Multiple, see https://www.synology.com/en-global/company/legal/terms_EULA
+URL:       https://www.synology.com/
+
+Source0: https://global.synologydownload.com/download/Utility/SynologyDriveClient/%{synology_version}-%{synology_release}/Ubuntu/Installer/synology-drive-client-%{synology_release}.x86_64.deb
+
+AutoReqProv: no
+Requires: glibc
+Requires: glib2
+Requires: gtk2
+Requires: fex-emu
+Requires: fex-emu-rootfs-fedora
+
+Conflicts: synology-drive
+
+%description
+Synology Drive Client allows you to sync your computers with Synology NAS and back up the computer to the NAS.
+
+%prep
+ar x %{_sourcedir}/synology-drive-client-%{synology_release}.x86_64.deb data.tar.xz
+tar xf data.tar.xz
+
+# disable auto update
+sed -i "s|https://utyupdate.synology.com||" opt/Synology/SynologyDrive/package/cloudstation/conf/update.conf
+sed -i "s|/getUpdate||" opt/Synology/SynologyDrive/package/cloudstation/conf/update.conf
+
+%install
+export QA_RPATHS=$(( 0x0002|0x0020 )) # ignore rpath error since 3.1.0-12920
+
+# software
+mkdir -p %{buildroot}/opt/Synology/
+cp -rp opt/Synology/SynologyDrive/ %{buildroot}/opt/Synology/
+
+# executable
+mkdir -p %{buildroot}%{_bindir}/
+install -Dm 755 usr/bin/synology-drive -t %{buildroot}%{_bindir}/
+
+# nautilus (installed in case the user wants to use Nautilus)
+mkdir -p %{buildroot}%{_libdir}/nautilus/extensions-3.0/
+install -Dm 644 usr/lib/nautilus/extensions-3.0/libnautilus-drive-extension.so -t %{buildroot}%{_libdir}/nautilus/extensions-3.0/
+mkdir -p %{buildroot}%{_libdir}/nautilus/extensions-4/
+install -Dm 644 usr/lib/nautilus/extensions-4/libnautilus-drive-extension-4.so -t %{buildroot}%{_libdir}/nautilus/extensions-4/
+
+# desktop
+mkdir -p %{buildroot}%{_datarootdir}/applications/
+install -Dm 644 usr/share/applications/synology-drive.desktop -t %{buildroot}%{_datarootdir}/applications/
+mkdir -p %{buildroot}%{_datarootdir}/icons/
+cp -rp usr/share/icons/hicolor/ %{buildroot}%{_datarootdir}/icons/
+
+# fex
+mkdir -p %{buildroot}/usr/share/fex-emu/
+cat << EOF > %{buildroot}/usr/share/fex-emu/Config.json
+{"Config":{"ExtendedVolatileMetadata":"","NeedsSeccomp":"0","ServerSocketPath":"","MonoHacks":"1","StartupSleepProcName":"","StartupSleep":"0","HideHypervisorBit":"0","StallProcess":"0","X87ReducedPrecision":"0","VolatileMetadata":"1","KernelUnalignedAtomicBackpatching":"1","StrictInProcessSplitLocks":"0","HalfBarrierTSOEnabled":"1","MemcpySetTSOEnabled":"0","VectorTSOEnabled":"0","TSOEnabled":"1","SMCChecks":"1","EnableGpuvisProfiling":"0","ProfileStats":"0","TelemetryDirectory":"","OutputLog":"server","SilentLog":"1","DisableTelemetry":"0","ForceSVEWidth":"0","ThunkConfig":"","ThunkGuestLibs":"\/usr\/share\/fex-emu\/GuestThunks","ThunkHostLibs":"\/usr\/lib64\/fex-emu\/HostThunks","RootFS":"\/usr\/share\/fex-emu\/RootFS\/default.erofs","CPUFeatureRegisters":"","HideHybrid":"1","SmallTSCScale":"1","HostFeatures":"0","EnableCodeCacheValidation":"0","DisableL2Cache":"0","EnableCodeCachingWIP":"0","X86Disassemble":"0","DISABLE_VIXL_INDIRECT_RUNTIME_CALLS":"1","MaxInst":"5000","Disassemble":"0","Multiblock":"1","InjectLibSegFault":"0","DynamicL1Cache":"0","DynamicL1CacheIncreaseCountHeuristic":"250","DynamicL1CacheDecreaseCountHeuristic":"50","SingleStep":"0","GdbServer":"0","DumpIR":"no","PassManagerDumpIR":"0","DumpGPRs":"0","O0":"0","GlobalJITNaming":"0","LibraryJITNaming":"0","BlockJITNaming":"0","GDBSymbols":"0"},"ThunksDB":{"fex_thunk_test":0,"asound":0,"drm":0,"Vulkan":0,"WaylandClient":0,"GL":0}}
+EOF
+
+mkdir -p %{buildroot}/usr/lib/binfmt.d/
+cat << EOF > %{buildroot}/usr/lib/binfmt.d/synology-drive.conf
+:synology-drive:M:0:\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x3e\x00:\xff\xff\xff\xff\xff\xfe\xfe\x00\x00\x00\x00\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/FEX:POCF
+EOF
+
+%files
+%license opt/Synology/SynologyDrive/LICENSE.txt
+%doc usr/share/doc/synology-drive/changelog.gz
+
+/opt/Synology/SynologyDrive/
+%{_bindir}/synology-drive
+%{_libdir}/nautilus/extensions-3.0/libnautilus-drive-extension.so
+%{_libdir}/nautilus/extensions-4/libnautilus-drive-extension-4.so
+%{_datarootdir}/applications/synology-drive.desktop
+%{_datarootdir}/icons/hicolor/16x16/apps/synology-drive.png
+%{_datarootdir}/icons/hicolor/24x24/apps/synology-drive.png
+%{_datarootdir}/icons/hicolor/32x32/apps/synology-drive.png
+%{_datarootdir}/icons/hicolor/48x48/apps/synology-drive.png
+%{_datarootdir}/icons/hicolor/64x64/apps/synology-drive.png
+%{_datarootdir}/icons/hicolor/128x128/apps/synology-drive.png
+%{_datarootdir}/icons/hicolor/256x256/apps/synology-drive.png
+%{_datarootdir}/icons/hicolor/512x512/apps/synology-drive.png
+/usr/share/fex-emu/Config.json
+/usr/lib/binfmt.d/synology-drive.conf
+
+%changelog
+* Sat Apr 11 2026 Michael Leithold <Michael.Leithold@web.de> - 4.0.2-17889
+- Version 4.0.2-17889 for Aarch64
+* Fri Jan 23 2026 Maxime Dirksen <dev@emixam.be> - 4.0.2-17889
+- Version 4.0.2-17889 of Synology Drive Client

--- a/synology-drive-aarch64.spec
+++ b/synology-drive-aarch64.spec
@@ -1,0 +1,98 @@
+%global synology_version 4.0.2
+%global synology_release 17889
+
+Name:      synology-drive
+Version:   %{synology_version}
+Release:   %{synology_release}%{?dist}
+Summary:   Unofficial RPM build of Synology Drive Client
+License:   Multiple, see https://www.synology.com/en-global/company/legal/terms_EULA
+URL:       https://www.synology.com/
+
+Source0: https://global.synologydownload.com/download/Utility/SynologyDriveClient/%{synology_version}-%{synology_release}/Ubuntu/Installer/synology-drive-client-%{synology_release}.x86_64.deb
+
+AutoReqProv: no
+Requires: glibc
+Requires: glib2
+Requires: gtk2
+Requires: fex-emu
+Requires: fex-emu-rootfs-fedora
+
+# For Nautilus integration
+Recommends: nautilus
+Recommends: nautilus-extensions
+
+# For tray icon on GNOME
+Recommends: gnome-shell-extension-appindicator
+
+Conflicts: synology-drive-noextra
+
+%description
+Synology Drive Client allows you to sync your computers with Synology NAS and back up the computer to the NAS.
+
+%prep
+ar x %{_sourcedir}/synology-drive-client-%{synology_release}.x86_64.deb data.tar.xz
+tar xf data.tar.xz
+
+# disable auto update
+sed -i "s|https://utyupdate.synology.com||" opt/Synology/SynologyDrive/package/cloudstation/conf/update.conf
+sed -i "s|/getUpdate||" opt/Synology/SynologyDrive/package/cloudstation/conf/update.conf
+
+%install
+export QA_RPATHS=$(( 0x0002|0x0020 )) # ignore rpath error since 3.1.0-12920
+
+# software
+mkdir -p %{buildroot}/opt/Synology/
+cp -rp opt/Synology/SynologyDrive/ %{buildroot}/opt/Synology/
+
+# executable
+mkdir -p %{buildroot}%{_bindir}/
+install -Dm 755 usr/bin/synology-drive -t %{buildroot}%{_bindir}/
+
+# nautilus
+mkdir -p %{buildroot}%{_libdir}/nautilus/extensions-3.0/
+install -Dm 644 usr/lib/nautilus/extensions-3.0/libnautilus-drive-extension.so -t %{buildroot}%{_libdir}/nautilus/extensions-3.0/
+mkdir -p %{buildroot}%{_libdir}/nautilus/extensions-4/
+install -Dm 644 usr/lib/nautilus/extensions-4/libnautilus-drive-extension-4.so -t %{buildroot}%{_libdir}/nautilus/extensions-4/
+
+# desktop
+mkdir -p %{buildroot}%{_datarootdir}/applications/
+install -Dm 644 usr/share/applications/synology-drive.desktop -t %{buildroot}%{_datarootdir}/applications/
+mkdir -p %{buildroot}%{_datarootdir}/icons/
+cp -rp usr/share/icons/hicolor/ %{buildroot}%{_datarootdir}/icons/
+
+# fex
+mkdir -p %{buildroot}/usr/share/fex-emu/
+cat << EOF > %{buildroot}/usr/share/fex-emu/Config.json
+{"Config":{"ExtendedVolatileMetadata":"","NeedsSeccomp":"0","ServerSocketPath":"","MonoHacks":"1","StartupSleepProcName":"","StartupSleep":"0","HideHypervisorBit":"0","StallProcess":"0","X87ReducedPrecision":"0","VolatileMetadata":"1","KernelUnalignedAtomicBackpatching":"1","StrictInProcessSplitLocks":"0","HalfBarrierTSOEnabled":"1","MemcpySetTSOEnabled":"0","VectorTSOEnabled":"0","TSOEnabled":"1","SMCChecks":"1","EnableGpuvisProfiling":"0","ProfileStats":"0","TelemetryDirectory":"","OutputLog":"server","SilentLog":"1","DisableTelemetry":"0","ForceSVEWidth":"0","ThunkConfig":"","ThunkGuestLibs":"\/usr\/share\/fex-emu\/GuestThunks","ThunkHostLibs":"\/usr\/lib64\/fex-emu\/HostThunks","RootFS":"\/usr\/share\/fex-emu\/RootFS\/default.erofs","CPUFeatureRegisters":"","HideHybrid":"1","SmallTSCScale":"1","HostFeatures":"0","EnableCodeCacheValidation":"0","DisableL2Cache":"0","EnableCodeCachingWIP":"0","X86Disassemble":"0","DISABLE_VIXL_INDIRECT_RUNTIME_CALLS":"1","MaxInst":"5000","Disassemble":"0","Multiblock":"1","InjectLibSegFault":"0","DynamicL1Cache":"0","DynamicL1CacheIncreaseCountHeuristic":"250","DynamicL1CacheDecreaseCountHeuristic":"50","SingleStep":"0","GdbServer":"0","DumpIR":"no","PassManagerDumpIR":"0","DumpGPRs":"0","O0":"0","GlobalJITNaming":"0","LibraryJITNaming":"0","BlockJITNaming":"0","GDBSymbols":"0"},"ThunksDB":{"fex_thunk_test":0,"asound":0,"drm":0,"Vulkan":0,"WaylandClient":0,"GL":0}}
+EOF
+
+mkdir -p %{buildroot}/usr/lib/binfmt.d/
+cat << EOF > %{buildroot}/usr/lib/binfmt.d/synology-drive.conf
+:synology-drive:M:0:\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x3e\x00:\xff\xff\xff\xff\xff\xfe\xfe\x00\x00\x00\x00\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/FEX:POCF
+EOF
+
+%files
+%license opt/Synology/SynologyDrive/LICENSE.txt
+%doc usr/share/doc/synology-drive/changelog.gz
+
+/opt/Synology/SynologyDrive/
+%{_bindir}/synology-drive
+%{_libdir}/nautilus/extensions-3.0/libnautilus-drive-extension.so
+%{_libdir}/nautilus/extensions-4/libnautilus-drive-extension-4.so
+%{_datarootdir}/applications/synology-drive.desktop
+%{_datarootdir}/icons/hicolor/16x16/apps/synology-drive.png
+%{_datarootdir}/icons/hicolor/24x24/apps/synology-drive.png
+%{_datarootdir}/icons/hicolor/32x32/apps/synology-drive.png
+%{_datarootdir}/icons/hicolor/48x48/apps/synology-drive.png
+%{_datarootdir}/icons/hicolor/64x64/apps/synology-drive.png
+%{_datarootdir}/icons/hicolor/128x128/apps/synology-drive.png
+%{_datarootdir}/icons/hicolor/256x256/apps/synology-drive.png
+%{_datarootdir}/icons/hicolor/512x512/apps/synology-drive.png
+/usr/share/fex-emu/Config.json
+/usr/lib/binfmt.d/synology-drive.conf
+
+%changelog
+* Sat Apr 11 2026 Michael Leithold <Michael.Leithold@web.de> - 4.0.2-17889
+- Version 4.0.2-17889 for Aarch64
+* Fri Jan 23 2026 Maxime Dirksen <dev@emixam.be> - 4.0.2-17889
+- Version 4.0.2-17889 of Synology Drive Client


### PR DESCRIPTION
I created spec files to install the Synology Drive Client together with FEX. So it will run on Aarch64/ARM64 processors. I also updated the README.

I tested it with Fedora 43 Workstation, GNOME and KDE.

There remains one issue: You cannot use it if you need QEMU for user mode emulation of x86_64 processors. I'm not sure about system mode emulation.