### PR TITLE
4.0.3-17892 for Aarch64/AMD64 and some minor typos/mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Page link : [COPR package](https://copr.fedorainfracloud.org/coprs/emixampp/syno
    3. `sudo dnf install ~/rpmbuild/RPMS/x86_64/synology-drive-noextra-*.x86_64.rpm`
 7. Clean build root : `rm -r ~/rpmbuild`
 
-### Experimental: build the package locally for Aarch64/ARM64 processors (e.g. Apple Silicon, Qualcomm Snapdragon)
+### Experimental: build the package locally for Aarch64/ARM64 processors (e.g. Apple Silicon, Qualcomm Snapdragon, NVIDIA RTX Spark)
 1. Install build tools : `sudo dnf install rpm-build rpmdevtools`
 2. `git clone https://github.com/EmixamPP/synology-drive.git`
 3. `cd synology-drive`
@@ -49,13 +49,13 @@ Page link : [COPR package](https://copr.fedorainfracloud.org/coprs/emixampp/syno
 5. For GNOME:
    1. `spectool -g -R synology-drive-aarch64.spec`
    2. `rpmbuild -ba synology-drive-aarch64.spec`
-   3. `sudo dnf install ~/rpmbuild/RPMS/x86_64/synology-drive-*.aarch64.rpm`
+   3. `sudo dnf install ~/rpmbuild/RPMS/aarch64/synology-drive-*.aarch64.rpm`
 6. For other desktop environments: 
    1. `spectool -g -R synology-drive-aarch64-noextra.spec`
    2. `rpmbuild -ba synology-drive-aarch64-noextra.spec`
-   3. `sudo dnf install ~/rpmbuild/RPMS/x86_64/synology-drive-noextra-*.aarch64.rpm`
+   3. `sudo dnf install ~/rpmbuild/RPMS/aarch64/synology-drive-noextra-*.aarch64.rpm`
 7. Clean build root : `rm -r ~/rpmbuild`
-**Attention**_**: This solution uses the FEX emulator. If you are using the QEMU emulator it will probalby break because binfmt_misc allows only one emulator to register for x86_64 binaries.
+**Attention**: This solution uses the FEX emulator. If you are using the QEMU emulator it will probalby break because binfmt_misc allows only one emulator to register for x86_64 binaries.
 
 ## Legal information
 Consult the [LICENSE](https://github.com/EmixamPP/synology-drive/blob/main/LICENSE).

--- a/synology-drive-aarch64-noextra.spec
+++ b/synology-drive-aarch64-noextra.spec
@@ -1,5 +1,5 @@
-%global synology_version 4.0.2
-%global synology_release 17889
+%global synology_version 4.0.3
+%global synology_release 17892
 
 Name:      synology-drive-noextra
 Version:   %{synology_version}
@@ -85,6 +85,8 @@ EOF
 /usr/lib/binfmt.d/synology-drive.conf
 
 %changelog
+* Sat Jun 06 2026 Michael Leithold <dMichael.Leithold@web.de> - 4.0.3-17892
+- Version 4.0.3-17892 of Synology Drive Client
 * Sat Apr 11 2026 Michael Leithold <Michael.Leithold@web.de> - 4.0.2-17889
 - Version 4.0.2-17889 for Aarch64
 * Fri Jan 23 2026 Maxime Dirksen <dev@emixam.be> - 4.0.2-17889

--- a/synology-drive-aarch64.spec
+++ b/synology-drive-aarch64.spec
@@ -1,5 +1,5 @@
-%global synology_version 4.0.2
-%global synology_release 17889
+%global synology_version 4.0.3
+%global synology_release 17892
 
 Name:      synology-drive
 Version:   %{synology_version}
@@ -92,6 +92,8 @@ EOF
 /usr/lib/binfmt.d/synology-drive.conf
 
 %changelog
+* Sat Jun 06 2026 Michael Leithold <dMichael.Leithold@web.de> - 4.0.3-17892
+- Version 4.0.3-17892 of Synology Drive Client
 * Sat Apr 11 2026 Michael Leithold <Michael.Leithold@web.de> - 4.0.2-17889
 - Version 4.0.2-17889 for Aarch64
 * Fri Jan 23 2026 Maxime Dirksen <dev@emixam.be> - 4.0.2-17889


### PR DESCRIPTION
I updated the spec files for Aarch64/AMD64 to 4.0.3-17892 and tested it with Fedora Workstation 43 (Gnome & KDE Plasma) I also corrected some typos and mistakes.